### PR TITLE
mod type 17 failed parse fix, scars pathfind error fix

### DIFF
--- a/OpenConstructionSet.Example.Scar.PathFindingFix/Program.cs
+++ b/OpenConstructionSet.Example.Scar.PathFindingFix/Program.cs
@@ -40,7 +40,7 @@ foreach (var race in races)
     race.Values["pathfind acceleration"] = pathfindAcceleration;
 
     // avoid changing for races that like water
-    if ((float)race.Values["water avoidance"] > 0)
+    if (race.Values.ContainsKey("water avoidance") && (float)race.Values["water avoidance"] > 0)
     {
         race.Values["water avoidance"] = waterAvoidance;
     }

--- a/OpenConstructionSet/ContextBuilder.cs
+++ b/OpenConstructionSet/ContextBuilder.cs
@@ -106,7 +106,8 @@ public class ContextBuilder : IContextBuilder
         {
             using var reader = new OcsReader(await File.ReadAllBytesAsync(file.Path).ConfigureAwait(false));
 
-            if (reader.ReadInt() != (int)DataFileType.Mod)
+            var dataFileType = reader.ReadInt();
+            if (dataFileType < (int)DataFileType.Mod)
             {
                 if (options.ThrowIfMissing)
                 {
@@ -116,7 +117,7 @@ public class ContextBuilder : IContextBuilder
                 return;
             }
 
-            reader.ReadHeader();
+            reader.ReadHeader(dataFileType);
 
             lastId = Math.Max(lastId, reader.ReadInt());
 

--- a/OpenConstructionSet/Data/DataFile.cs
+++ b/OpenConstructionSet/Data/DataFile.cs
@@ -30,8 +30,8 @@ public class DataFile : IDataFile
 
         using var reader = new OcsReader(buffer);
 
-        var type = (DataFileType)reader.ReadInt();
-        var header = type == DataFileType.Mod ? reader.ReadHeader() : null;
+        var type = reader.ReadInt();
+        var header = type >= (int)DataFileType.Mod ? reader.ReadHeader(type) : null;
         var lastId = reader.ReadInt();
 
         return new(type, header, lastId, reader.ReadItems());

--- a/OpenConstructionSet/Data/DataFileData.cs
+++ b/OpenConstructionSet/Data/DataFileData.cs
@@ -21,6 +21,21 @@ public class DataFileData
     }
 
     /// <summary>
+    /// Creates a new <see cref="DataFileData"/>.
+    /// </summary>
+    /// <param name="type">The data file's type integer.</param>
+    /// <param name="header">The mod's header.</param>
+    /// <param name="lastId">The last ID number used when creating new items.</param>
+    /// <param name="items">The collection of <see cref="Item"/>s of the <see cref="IDataFile"/>.</param>
+    public DataFileData(int type, Header? header, int lastId, IEnumerable<Item> items)
+    {
+        Type = (DataFileType)type;
+        LastId = lastId;
+        Items = new(items);
+        Header = header;
+    }
+
+    /// <summary>
     /// The <see cref="Header"/> if it is a <see cref="DataFileType.Mod"/> file.
     /// <c>null</c> for other data files
     /// </summary>

--- a/OpenConstructionSet/IO/OcsReader.cs
+++ b/OpenConstructionSet/IO/OcsReader.cs
@@ -45,11 +45,20 @@ public sealed class OcsReader : IDisposable
     /// Read a <see cref="Header"/> object from the data.
     /// </summary>
     /// <returns>A <see cref="Header"/> object read from the data.</returns>
-    public Header ReadHeader() => new(ReadInt(), ReadString(), ReadString())
+    public Header ReadHeader(int type)
     {
-        Dependencies = ReadStringList().ToList(),
-        References = ReadStringList().ToList()
-    };
+        Header h = new();
+        var endPosition = type == 17 ? ReadInt()/*header length*/ + reader.BaseStream.Position : 0;
+        h.Version = ReadInt();
+        h.Author = ReadString();
+        h.Description = ReadString();
+        h.Dependencies = ReadStringList().ToList();
+        h.References = ReadStringList().ToList();
+
+        if (type == 17) reader.ReadBytes((int)(endPosition - reader.BaseStream.Position));
+
+        return h;
+    }
 
     /// <summary>
     /// Read an <see cref="Instance"/> from the data.

--- a/OpenConstructionSet/Mods/ModFile.cs
+++ b/OpenConstructionSet/Mods/ModFile.cs
@@ -32,9 +32,9 @@ public class ModFile : IModFile
 
         using var reader = new OcsReader(buffer);
 
-        var type = (DataFileType)reader.ReadInt();
+        var type = reader.ReadInt();
 
-        return new(reader.ReadHeader(), reader.ReadInt(), reader.ReadItems(), await ReadInfoAsync(cancellationToken).ConfigureAwait(false));
+        return new(reader.ReadHeader(type), reader.ReadInt(), reader.ReadItems(), await ReadInfoAsync(cancellationToken).ConfigureAwait(false));
     }
 
     /// <inheritdoc/>
@@ -42,7 +42,8 @@ public class ModFile : IModFile
     {
         using var reader = new OcsReader(File.OpenRead(Path));
 
-        return Task.FromResult((DataFileType)reader.ReadInt() == DataFileType.Mod ? reader.ReadHeader() : throw new InvalidDataException("Target file is not a valid mod"));
+        var type = reader.ReadInt();
+        return Task.FromResult(type >= (int)DataFileType.Mod ? reader.ReadHeader(type) : throw new InvalidDataException("Target file is not a valid mod"));
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
OSC cant parse mod files of type 17
Mod for example: FF7 Tifa npc on Steam id: 2678023163. In my load order quite many of them.

There are some rough changes for type check and because the PR was made in develop branch. There was added for type 17 reading of second integer in mod file as headr's size and change stream position to end of the header's data because I dont know which data are in bytes after masters and reference, before items data.